### PR TITLE
Kafka resource

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -23,10 +23,11 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"aiven_project":      resourceProject(),
-			"aiven_service":      resourceService(),
-			"aiven_database":     resourceDatabase(),
-			"aiven_service_user": resourceServiceUser(),
+			"aiven_project":       resourceProject(),
+			"aiven_service":       resourceService(),
+			"aiven_kafka_service": resourceKafkaService(),
+			"aiven_database":      resourceDatabase(),
+			"aiven_service_user":  resourceServiceUser(),
 		},
 
 		ConfigureFunc: func(d *schema.ResourceData) (interface{}, error) {

--- a/service_change.go
+++ b/service_change.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/jelmersnoeck/aiven"
+	"log"
+	"time"
+)
+
+type ServiceChangeWaiter struct {
+	Client      *aiven.Client
+	Project     string
+	ServiceName string
+}
+
+func (w *ServiceChangeWaiter) RefreshFunc() resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		service, err := w.Client.Services.Get(
+			w.Project,
+			w.ServiceName,
+		)
+
+		log.Printf("[DEBUG] Got %s state while waiting for service to be running.", service.State)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return service, service.State, nil
+	}
+}
+
+func (w *ServiceChangeWaiter) Conf() *resource.StateChangeConf {
+	state := &resource.StateChangeConf{
+		Pending: []string{"REBUILDING"},
+		Target:  []string{"RUNNING"},
+		Refresh: w.RefreshFunc(),
+	}
+	state.Delay = 10 * time.Second
+	state.Timeout = 10 * time.Minute
+	state.MinTimeout = 2 * time.Second
+	return state
+
+}


### PR DESCRIPTION
Had to base this PR from https://github.com/jelmersnoeck/terraform-provider-aiven/pull/7 Will update once #7 is merged.

This is to give an idea what it would look like. There is most likely a way to set this up so that we can leverage some form of inheritance/compositing. Right now it's mostly copy paste, but we've got plans to add the kafka specific functions such as specifying the default ACLs or enabling or disabling various kafka services. This layer will convert the terraform Schema into the map provided to the create service field `user_config` so this will not leak into the aiven client library.