### PR TITLE
Removes service user update

### DIFF
--- a/resource_service_user.go
+++ b/resource_service_user.go
@@ -11,7 +11,6 @@ func resourceServiceUser() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceServiceUserCreate,
 		Read:   resourceServiceUserRead,
-		Update: resourceServiceUserUpdate,
 		Delete: resourceServiceUserDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -106,10 +105,6 @@ func resourceServiceUserRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	return errors.New("User not found")
-}
-
-func resourceServiceUserUpdate(d *schema.ResourceData, m interface{}) error {
-	return nil
 }
 
 func resourceServiceUserDelete(d *schema.ResourceData, m interface{}) error {


### PR DESCRIPTION
@jelmersnoeck This removes the no-op service user update. In the 0.11 series of terraform having this present gives the following error on run:

```
Error: provider.aiven: Internal validation of the provider failed! This is always a bug
with the provider itself, and not a user issue. Please report
this bug:

1 error occurred:

* resource aiven_service_user: All fields are ForceNew or Computed w/out Optional, Update is superfluous
```