### PR TITLE
Add support for User Config and Kafka User Config checking.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -147,10 +147,10 @@
   revision = "d1caa6c97c9fc1cc9e83bbe34d0603f9ff0ce8bd"
 
 [[projects]]
-  branch = "master"
   name = "github.com/jelmersnoeck/aiven"
   packages = ["."]
-  revision = "2a0063b2df59ff374a309ecdaa9d926b79a83df8"
+  revision = "bb544f4dfbe14582fa498175771acd8409b9c2eb"
+  source = "github.com/jelmersnoeck/aiven"
 
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
@@ -191,6 +191,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f87190b1b411f33d34e548c1128538e55ce781ecbb2ae9d6a0101a9362c1b7a4"
+  inputs-digest = "64509b845f14e462382d5638a9f26f2ecdd2f520f371a2bd728bbc7ac11d9883"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,8 @@
 
 [[constraint]]
   name = "github.com/jelmersnoeck/aiven"
-  version = "0.0.2"
+  revision = "bb544f4dfbe14582fa498175771acd8409b9c2eb"
+  source = "github.com/jelmersnoeck/aiven"
 
 [prune]
   go-tests = true

--- a/resource_service.go
+++ b/resource_service.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/jelmersnoeck/aiven"
@@ -14,12 +15,11 @@ func resourceService() *schema.Resource {
 		Update: resourceServiceUpdate,
 		Delete: resourceServiceDelete,
 
-		// TODO: add user config
 		Schema: map[string]*schema.Schema{
 			"project": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Target cloud",
+				Description: "Target project",
 				ForceNew:    true,
 			},
 			"cloud": {
@@ -64,13 +64,17 @@ func resourceService() *schema.Resource {
 				Computed:    true,
 				Description: "Service state",
 			},
+			"user_config": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "Service type-specific settings",
+			},
 		},
 	}
 }
 
 func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
 	client := m.(*aiven.Client)
-
 	service, err := client.Services.Create(
 		d.Get("project").(string),
 		aiven.CreateServiceRequest{
@@ -79,6 +83,7 @@ func resourceServiceCreate(d *schema.ResourceData, m interface{}) error {
 			Plan:        d.Get("plan").(string),
 			ServiceName: d.Get("service_name").(string),
 			ServiceType: d.Get("service_type").(string),
+			UserConfig:  transformUserConfig(d),
 		},
 	)
 
@@ -136,10 +141,11 @@ func resourceServiceUpdate(d *schema.ResourceData, m interface{}) error {
 		d.Get("project").(string),
 		d.Get("service_name").(string),
 		aiven.UpdateServiceRequest{
-			Cloud:     d.Get("cloud").(string),
-			GroupName: d.Get("group_name").(string),
-			Plan:      d.Get("plan").(string),
-			Powered:   true,
+			Cloud:      d.Get("cloud").(string),
+			GroupName:  d.Get("group_name").(string),
+			Plan:       d.Get("plan").(string),
+			Powered:    true,
+			UserConfig: transformUserConfig(d),
 		},
 	)
 	if err != nil {
@@ -177,4 +183,42 @@ func resourceServiceWait(d *schema.ResourceData, m interface{}) error {
 	}
 
 	return nil
+}
+
+// Aiven requires field types on received JSON to be correctly typed. If the service type is known
+// transform the Terraform type (one of string, list, or map) into the appropriate Go type and
+// return the modified user config. If the  service does not have a special handler the user config
+// is returned as-is with the default Terraform types associated.
+func transformUserConfig(d *schema.ResourceData) map[string]interface{} {
+	serviceType := d.Get("service_type").(string)
+	userConfig := d.Get("user_config").(map[string]interface{})
+
+	if serviceType == "kafka" {
+		userConfig = transformKafkaUserConfig(userConfig)
+	}
+
+	return userConfig
+}
+
+// Transform the kafka service user config from Terraform's built-in types to the appropriate
+// golang types.
+func transformKafkaUserConfig(userConfig map[string]interface{}) map[string]interface{} {
+	newUserConfig := make(map[string]interface{})
+	kafkaConnectInterface, ok := userConfig["kafka_connect"]
+	if ok {
+		newUserConfig["kafka_connect"] = stringToBool(kafkaConnectInterface.(string))
+	}
+	kafkaRestInterface, ok := userConfig["kafka_rest"]
+	if ok {
+		newUserConfig["kafka_rest"] = stringToBool(kafkaRestInterface.(string))
+	}
+	schemaRegistryInterface, ok := userConfig["schema_registry"]
+	if ok {
+		newUserConfig["schema_registry"] = stringToBool(schemaRegistryInterface.(string))
+	}
+	return newUserConfig
+}
+
+func stringToBool(maybeBool string) bool {
+	return maybeBool == "1" || strings.ToLower(maybeBool) == "true"
 }


### PR DESCRIPTION
@jelmersnoeck integrates support for user config into the Aiven provider. Before merging this I'll have to either update the dep to point to master of the aiven repo, or we'll need to cut a `0.1.0` or `0.0.3` in the Aiven repo.

One other note -- I had to add some type transformations on the user config because [Terraform converts bools to strings](https://www.terraform.io/docs/configuration/variables.html#booleans). The Aiven API uses JSON Schema or something similar to type check values, and was thus rejecting the API requests without the type munging you see here.

Its also worth noting that Aiven doesn't document whats in the `user_config` for each service. We're reaching out to them to see if we can get a list of whats officially documented without having to reverse-engineer the API w/ list/get on the service.