### PR TITLE
Wait for Kafka auxillary services to start up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 terraform-provider-aiven
 terraform.tfvars
 *.tfstate*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 terraform-provider-aiven
 terraform.tfvars
 *.tfstate*

--- a/resource_service.go
+++ b/resource_service.go
@@ -224,7 +224,7 @@ func resourceServiceWait(d *schema.ResourceData, m interface{}) error {
 
 // Aiven requires field types on received JSON to be correctly typed. If the service type is known
 // transform the Terraform type (one of string, list, or map) into the appropriate Go type and
-// return the modified user config. If the  service does not have a special handler the user config
+// return the modified user config. If the service does not have a special handler the user config
 // is returned as-is with the default Terraform types associated.
 func transformUserConfig(d *schema.ResourceData) map[string]interface{} {
 	serviceType := d.Get("service_type").(string)

--- a/service_change.go
+++ b/service_change.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"log"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/jelmersnoeck/aiven"
+	"log"
+	"net/http"
 )
 
 // ServiceChangeWaiter is used to refresh the Aiven Service endpoints when
@@ -16,7 +17,13 @@ type ServiceChangeWaiter struct {
 	ServiceName string
 }
 
-// RefreshFunc will call the Aiven client and refresh it's state.
+const (
+	aivenTargetState                = "RUNNING"
+	aivenPendingState               = "REBUILDING"
+	aivenKafkaServicesStartingState = "WAITING_FOR_KAFKA"
+)
+
+// RefreshFunc will call the Aiven client and refresh its state.
 func (w *ServiceChangeWaiter) RefreshFunc() resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		service, err := w.Client.Services.Get(
@@ -30,15 +37,62 @@ func (w *ServiceChangeWaiter) RefreshFunc() resource.StateRefreshFunc {
 			return nil, "", err
 		}
 
-		return service, service.State, nil
+		// If this is a Kafka service, wait for its component parts (i.e. Kafka Connect,
+		// Kafka REST, and Schema Registry) to be ready
+		state := service.State
+		if state == aivenTargetState && service.Type == "kafka" {
+			if !kafkaServicesReady(service) {
+				state = aivenKafkaServicesStartingState
+			}
+		}
+
+		return service, state, nil
 	}
+}
+
+// If any of Kafka Rest, Schema Registry, and Kafka Connect are enabled, refresh
+// their state to check if they're ready
+func kafkaServicesReady(service *aiven.Service) bool {
+	kafkaRestEnabled, schemaRegistryEnabled, kafkaConnectEnabled := false, false, false
+	userConfig := service.UserConfig.(map[string]interface{})
+	if enabled, ok := userConfig["kafka_rest"]; ok {
+		kafkaRestEnabled = enabled.(bool)
+	}
+	if enabled, ok := userConfig["schema_registry"]; ok {
+		schemaRegistryEnabled = enabled.(bool)
+	}
+	if enabled, ok := userConfig["kafka_connect"]; ok {
+		kafkaConnectEnabled = enabled.(bool)
+	}
+
+	if !kafkaRestEnabled && !schemaRegistryEnabled && !kafkaConnectEnabled {
+		return true
+	}
+
+	if kafkaRestEnabled {
+		if _, err := http.Get(service.ConnectionInfo.KafkaRestURI); err != nil {
+			return false
+		}
+	}
+	if schemaRegistryEnabled {
+		if _, err := http.Get(service.ConnectionInfo.SchemaRegistryURI); err != nil {
+			return false
+		}
+	}
+	if kafkaConnectEnabled {
+		if _, err := http.Get(service.ConnectionInfo.KafkaConnectURI); err != nil {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Conf sets up the configuration to refresh.
 func (w *ServiceChangeWaiter) Conf() *resource.StateChangeConf {
 	state := &resource.StateChangeConf{
-		Pending: []string{"REBUILDING"},
-		Target:  []string{"RUNNING"},
+		Pending: []string{aivenPendingState, aivenKafkaServicesStartingState},
+		Target:  []string{aivenTargetState},
 		Refresh: w.RefreshFunc(),
 	}
 	state.Delay = 10 * time.Second


### PR DESCRIPTION
@jelmersnoeck @FranOis 

When Aiven creates a Kafka service with Kafka Connect, and/or, Kafka Rest, and/or schema registry enabled, Aiven will report that Kafka is ready potentially before any of those peripheral services are actually ready. This PR ensures that when a resource is a Kafka service the resource shouldn't be considered ready until all the peripheral services are healthy; if a service is reachable, it is considered ready. This is a feature @benjigoldberg and I need so that resources that are dependent on Kafka Connect being ready don't fail immediately after Terraform creates the Kafka service in Aiven. 